### PR TITLE
Improve authentication modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# ICU
+# NFC Password Manager
+
+This repository provides a starting point for a cross-platform password manager that combines multiple authentication factors:
+
+- Biometrics (e.g. fingerprint, FaceID)
+- PIN-based fallback
+- A NFC tag that stores an encrypted master key
+
+All user data is encrypted locally using SQLCipher. The master key is derived
+from the user's PIN with PBKDF2 and can be stored on an NFC tag. Each payload on
+the tag bundles its own salt and IV so the key can always be recovered offline.
+The PIN itself is never written to disk.
+
+The project is organized into separate modules for easier maintenance.
+
+See the `docs/` directory for further details about the architecture.

--- a/auth_core/README.md
+++ b/auth_core/README.md
@@ -1,0 +1,4 @@
+# auth_core
+
+This package contains the core authentication logic shared between platforms. It handles
+biometric checks, PIN verification and orchestrates access to the encrypted database.

--- a/auth_core/lib/auth_core.dart
+++ b/auth_core/lib/auth_core.dart
@@ -1,0 +1,92 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+/// Core authentication utilities handling biometrics and NFC key retrieval.
+class AuthCore {
+  final LocalAuthentication _auth = LocalAuthentication();
+
+  /// Performs a biometric check. Returns true if the user successfully
+  /// authenticated using fingerprint or face recognition.
+  Future<bool> authenticateBiometrics() async {
+    return _auth.authenticate(
+      localizedReason: 'Authenticate to access your vault',
+      options: const AuthenticationOptions(biometricOnly: true),
+    );
+  }
+
+  /// Reads the encrypted master key from an NFC tag and decrypts it using the
+  /// provided [pin]. The payload stored on the tag must contain the salt (16 B),
+  /// the AES-GCM IV (12 B) and the ciphertext including MAC.
+  Future<Uint8List?> readMasterKey(String pin) async {
+    Uint8List? encrypted;
+    Uint8List? salt;
+    Uint8List? iv;
+
+    await NfcManager.instance.startSession(onDiscovered: (tag) async {
+      final ndef = Ndef.from(tag);
+      if (ndef != null) {
+        final payload = ndef.cachedMessage?.records.first.payload;
+        if (payload != null && payload.length >= 28) {
+          salt = Uint8List.sublistView(payload, 0, 16);
+          iv = Uint8List.sublistView(payload, 16, 28);
+          encrypted = Uint8List.sublistView(payload, 28);
+        }
+      }
+      NfcManager.instance.stopSession();
+    });
+
+    if (encrypted == null || salt == null || iv == null) {
+      return null;
+    }
+
+    final pbkdf2 = Pbkdf2(
+      macAlgorithm: Hmac.sha256(),
+      iterations: 100000,
+      bits: 256,
+    );
+    final secretKey = await pbkdf2.deriveKey(
+      secretKey: SecretKey(pin.codeUnits),
+      nonce: salt!,
+    );
+
+    final cipher = AesGcm.with256bits();
+    final box = SecretBox(encrypted!, nonce: iv!, mac: Mac.empty);
+    final key = await cipher.decrypt(box, secretKey: secretKey);
+    return Uint8List.fromList(key);
+  }
+
+  /// Encrypts [masterKey] with a key derived from [pin] and writes it to the
+  /// supplied NFC [tag]. Salt and IV are generated randomly and stored together
+  /// with the ciphertext on the tag.
+  Future<void> writeMasterKey(Tag tag, Uint8List masterKey, String pin) async {
+    final random = Random.secure();
+    final salt =
+        Uint8List.fromList(List<int>.generate(16, (_) => random.nextInt(256)));
+
+    final pbkdf2 = Pbkdf2(
+      macAlgorithm: Hmac.sha256(),
+      iterations: 100000,
+      bits: 256,
+    );
+    final secretKey = await pbkdf2.deriveKey(
+      secretKey: SecretKey(pin.codeUnits),
+      nonce: salt,
+    );
+
+    final cipher = AesGcm.with256bits();
+    final box = await cipher.encrypt(masterKey, secretKey: secretKey);
+    final payload = Uint8List.fromList(salt + box.nonce + box.cipherText);
+
+    final ndef = Ndef.from(tag);
+    if (ndef == null) {
+      throw Exception('NDEF not supported');
+    }
+    await ndef.write(NdefMessage([
+      NdefRecord.mime('application/vnd.myapp.masterkey', payload),
+    ]));
+  }
+}

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,19 @@
+# Architecture Overview
+
+The application uses a multi factor authentication flow combining biometrics, a user PIN and a NFC tag. The master key for the local password database is stored encrypted on the NFC tag. When the user launches the app the following steps occur:
+
+1. **Biometric check** using the device API. A failure falls back to PIN entry.
+2. **NFC tag** is scanned. The encrypted master key together with a random salt and IV is read from the tag.
+3. The **master key** is decrypted using PBKDF2 derived from the PIN. AES‑GCM ensures confidentiality and integrity.
+4. The **SQLCipher** database is opened with this key and the password vault becomes available.
+
+The project is split into several modules:
+
+- `auth_core/` – shared logic for biometrics, PIN handling and session orchestration
+- `ui_app/` – the Flutter application providing the user interface
+- `platform_plugins/` – native plugins for NFC and secure key operations
+
+Each encrypted payload stored on the tag contains its own 16‑byte salt and
+12‑byte IV so the key derivation and decryption steps are fully
+self‑contained. The integrity tag produced by AES‑GCM is appended to the
+ciphertext and verified during decryption.

--- a/platform_plugins/README.md
+++ b/platform_plugins/README.md
@@ -1,0 +1,4 @@
+# platform_plugins
+
+Native plugins that handle low level operations such as NFC access and secure
+key storage using the platform's keystore.

--- a/platform_plugins/android/WriteMasterKey.kt
+++ b/platform_plugins/android/WriteMasterKey.kt
@@ -1,0 +1,45 @@
+package com.example.platform_plugins
+
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Example helper that encrypts a master key with PBKDF2 + AES/GCM and
+ * writes it onto an NFC tag. The payload layout is:
+ *   salt(16) | iv(12) | ciphertext
+ */
+object WriteMasterKey {
+    fun write(tag: Tag, masterKey: ByteArray, pin: String) {
+        val random = SecureRandom()
+        val salt = ByteArray(16).also { random.nextBytes(it) }
+
+        val spec = PBEKeySpec(pin.toCharArray(), salt, 100_000, 256)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val keyBytes = factory.generateSecret(spec).encoded
+        val aesKey = SecretKeySpec(keyBytes, "AES")
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, aesKey)
+        val iv = cipher.iv
+        val encrypted = cipher.doFinal(masterKey)
+
+        val payload = salt + iv + encrypted
+        val ndef = Ndef.get(tag) ?: throw IllegalArgumentException("NDEF not supported")
+        ndef.connect()
+        try {
+            val record = NdefRecord.createMime("application/vnd.myapp.masterkey", payload)
+            val message = NdefMessage(arrayOf(record))
+            ndef.writeNdefMessage(message)
+        } finally {
+            ndef.close()
+        }
+    }
+}

--- a/ui_app/README.md
+++ b/ui_app/README.md
@@ -1,0 +1,4 @@
+# ui_app
+
+Flutter application that presents the user interface for the password manager. It uses
+`auth_core` for authentication tasks and stores credentials in a local SQLCipher database.

--- a/ui_app/lib/main.dart
+++ b/ui_app/lib/main.dart
@@ -1,0 +1,3 @@
+void main() {
+  // Placeholder entry point
+}


### PR DESCRIPTION
## Summary
- implement biometric and NFC helper in `auth_core`
- add Kotlin helper for writing master key to NFC
- document improved security considerations
- clarify README description of salt and IV usage

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d717b900c8329a6bf1bbed51dee55